### PR TITLE
specify pycoin version to install

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,7 +12,6 @@ of the derivation paths in the wrong endian.
 
 ```
 # python3 -m pip install --editable .
-# rehash
 # pbst_dump data/example.psbt
 ```
 

--- a/setup.py
+++ b/setup.py
@@ -13,6 +13,7 @@ setup(
     python_requires='>3.5.2',
     install_requires=[
         'Click',
+        'pycoin == 0.80'
     ],
     entry_points='''
         [console_scripts]


### PR DESCRIPTION
the latest version of pycoin breaks this tool as they changed the names of various pycoin modules

by specifying the version of pycoin that gets installed, the tool can still work